### PR TITLE
MOB-8428: Support for 16kb pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /captures
 .externalNativeBuild
 .cxx
+.kotlin/sessions

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.5.31"
+    ext.kotlin_version = "2.1.21"
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.9.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "2.1.21"
+    ext {
+        kotlin_version = "2.1.21"
+        minSdkVersion = 26
+        compileSdkVersion = 35
+        targetSdkVersion = 35
+    }
     repositories {
         google()
         mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Tue Mar 30 16:57:53 PDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
+networkTimeout=10000
+validateDistributionUrl=true
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/renderscript-toolkit/build.gradle
+++ b/renderscript-toolkit/build.gradle
@@ -46,6 +46,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++17"
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }

--- a/renderscript-toolkit/build.gradle
+++ b/renderscript-toolkit/build.gradle
@@ -33,12 +33,13 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "31.0.0"
+    namespace 'com.google.android.renderscript_hover'
 
+    ndkVersion = "27.1.12297006" // It's safest to match to our Camera SDK's NDK version, but not necessarily required
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 31
+        compileSdkVersion 35
+        minSdkVersion 26
+        targetSdkVersion 35
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -66,6 +67,9 @@ android {
         cmake {
             path file('src/main/cpp/CMakeLists.txt')
         }
+    }
+    publishing {
+        singleVariant("release") {}
     }
 }
 

--- a/renderscript-toolkit/build.gradle
+++ b/renderscript-toolkit/build.gradle
@@ -37,9 +37,9 @@ android {
 
     ndkVersion = "27.1.12297006" // It's safest to match to our Camera SDK's NDK version, but not necessarily required
     defaultConfig {
-        compileSdkVersion 35
-        minSdkVersion 26
-        targetSdkVersion 35
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
+        compileSdk rootProject.compileSdkVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/renderscript-toolkit/build.gradle
+++ b/renderscript-toolkit/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'maven-publish'
 }
 
-def libVersion = "1.0.0"
+def libVersion = "1.0.1"
 def libGroup = "to.hover.capture.internal"
 def libId = "renderscript"
 

--- a/renderscript-toolkit/src/main/java/com/google/android/renderscript_hover/Toolkit.kt
+++ b/renderscript-toolkit/src/main/java/com/google/android/renderscript_hover/Toolkit.kt
@@ -1520,7 +1520,7 @@ internal fun validateBitmap(
 }
 
 internal fun createCompatibleBitmap(inputBitmap: Bitmap) =
-    Bitmap.createBitmap(inputBitmap.width, inputBitmap.height, inputBitmap.config)
+    Bitmap.createBitmap(inputBitmap.width, inputBitmap.height, inputBitmap.config!!)
 
 internal fun validateHistogramDotCoefficients(
     coefficients: FloatArray?,

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -4,13 +4,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "31.0.0"
-
+    namespace 'com.google.android.renderscript_test'
     defaultConfig {
         applicationId "com.google.android.renderscript_test"
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdkVersion 26
+        targetSdkVersion 35
+        compileSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -39,6 +38,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'com.google.android.material:material:1.4.0'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -7,9 +7,9 @@ android {
     namespace 'com.google.android.renderscript_test'
     defaultConfig {
         applicationId "com.google.android.renderscript_test"
-        minSdkVersion 26
-        targetSdkVersion 35
-        compileSdkVersion 35
+        minSdkVersion rootProject.minSdkVersion
+        targetSdkVersion rootProject.targetSdkVersion
+        compileSdk rootProject.compileSdkVersion
         versionCode 1
         versionName "1.0"
 

--- a/test-app/src/main/java/com/google/android/renderscript_test/BufferUtils.kt
+++ b/test-app/src/main/java/com/google/android/renderscript_test/BufferUtils.kt
@@ -480,7 +480,7 @@ fun vectorSizeOfBitmap(bitmap: Bitmap): Int {
 }
 
 fun duplicateBitmap(original: Bitmap): Bitmap {
-    val copy = Bitmap.createBitmap(original.width, original.height, original.config)
+    val copy = Bitmap.createBitmap(original.width, original.height, original.config!!)
     val canvas = Canvas(copy)
     canvas.drawBitmap(original, 0f, 0f, null)
     return copy


### PR DESCRIPTION
Updates AGP, NDK, and SDK versions to be able to support 16KB pages. I simply matched the versions we use in Camera SDK to be safe. I also had to upgrade other some helper libs as things started breaking.

This does NOT an attempt to modernize the project in terms of best practice with Build files, but rather keep it simple and upgrade what is necessary as we don't need to compile this very often.

There is a test suite, but I noticed that not all tests pass on older devices I have (but they were fine Samsung S20 and Pixel). However, the only one we use is YUV conversion and that one consistently passed on all 4 test devices I have.
<img width="1023" height="308" alt="Screenshot 2025-08-08 at 5 13 04 PM" src="https://github.com/user-attachments/assets/d3eb7c7d-0505-4a98-b805-49e8a73ce4f8" />

I compiled and used in our Camera sample as well and used [their test script](https://developer.android.com/guide/practices/page-sizes#alignment-use-script) to confirm that the binary is now aligned for 16KB support (before it would say UNALIGNED)
<img width="1169" height="621" alt="Screenshot 2025-08-08 at 5 35 12 PM" src="https://github.com/user-attachments/assets/8afe6140-5f25-4d4a-9a79-d1d62f76bc83" />
